### PR TITLE
Setup/plumbing

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,0 +1,18 @@
+export const LOAD_RECORD = 'LOAD_RECORD';
+export const SAVE_RECORD = 'SAVE_RECORD';
+
+export function addRecord(price, currency = 'XTS', description, category, image, datetime = (new Date).toISOString()) {
+  return {
+    type: SAVE_RECORD,
+    content: {
+      price: {
+        currency: currency,
+        value: price,
+      },
+      description: description,
+      datetime: datetime,
+      attachment: image,
+      category: category,
+    }
+  };
+}

--- a/components/RecordListItem.js
+++ b/components/RecordListItem.js
@@ -16,17 +16,17 @@ export default class RecordListItem extends Component {
   }
 
   render() {
-    const record = this.state.record;
+    var record = this.state.record;
 
     return(
       <View>
         <Text style={styles.leftColor}> </Text>
         <View style={styles.recordData}>
-          <Text numberOfLines={1} style={styles.descriptionText}>{record.description}</Text>
-          <Text style={styles.datetimeText}>{record.datetime}</Text>
+          <Text numberOfLines={1} style={styles.descriptionText}>{this.props.record.description}</Text>
+          <Text style={styles.datetimeText}>{this.props.record.datetime}</Text>
         </View>
         <View style = {styles.price}>
-          <Text style={styles.priceText}>{record.price.currency} {record.price.value}</Text>
+          <Text style={styles.priceText}>{this.props.record.price.currency} {this.props.record.price.value}</Text>
         </View>
       </View>
     );

--- a/components/RecordListViewIOS.js
+++ b/components/RecordListViewIOS.js
@@ -9,10 +9,13 @@ import RecordListItem from './RecordListItem';
 import styles from '../styles/Initial';
 
 export default (props) => {
-  const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
-  const renderRecord = (r) => {
+  //const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
+  let ds = new ListView.DataSource({rowHasChanged: function (r1, r2) {
+    return true; //(r1 !== r2);
+  }});
+  const renderRecord = (rowData, sectionID, rowID, highlightRow) => {
     return (
-      <RecordListItem record={r} />
+      <RecordListItem record={rowData} />
     );
   };
   return(

--- a/components/RecordListViewIOS.js
+++ b/components/RecordListViewIOS.js
@@ -13,7 +13,7 @@ import styles from '../styles/Initial';
 // Shouldn't use of Provider expose the store to all the components contained
 // within the Provider or does it work differently for connected components?
 const RecordListViewIOS = (props, x, y, z) => {
-  const renderRecord = (rowData, sectionID, rowID, highlightRow) => {
+  var renderRecord = (rowData, sectionID, rowID, highlightRow) => {
     console.log("record", rowData);
     return (
       <RecordListItem record={rowData} />

--- a/components/RecordListViewIOS.js
+++ b/components/RecordListViewIOS.js
@@ -8,23 +8,20 @@ import React, {
 import RecordListItem from './RecordListItem';
 import styles from '../styles/Initial';
 
-export default class RecordListViewIOS extends Component {
-
-  render() {
-    return(
-      <ScrollView style={styles.list}>
-        <ListView
-          dataSource={this.props.dataSource}
-          renderRow = {this.renderRecord}
-          style = {styles.ListView}
-        ></ListView>
-      </ScrollView>
+export default (props) => {
+  const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
+  const renderRecord = (r) => {
+    return (
+      <RecordListItem record={r} />
     );
-  }
-
-  renderRecord(dataSource) {
-    return(
-      <RecordListItem record={dataSource} />
-    );
-  }
-}
+  };
+  return(
+    <ScrollView style={styles.list}>
+      <ListView
+        dataSource={ds.cloneWithRows(props.records)}
+        renderRow = {renderRecord}
+        style = {styles.ListView}
+      ></ListView>
+    </ScrollView>
+  );
+};

--- a/components/RecordListViewIOS.js
+++ b/components/RecordListViewIOS.js
@@ -3,28 +3,37 @@ import React, {
   ListView,
   ScrollView,
   Text,
+  PropTypes,
 } from 'react-native';
 
 import RecordListItem from './RecordListItem';
 import styles from '../styles/Initial';
 
-export default (props) => {
-  //const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
-  let ds = new ListView.DataSource({rowHasChanged: function (r1, r2) {
-    return true; //(r1 !== r2);
-  }});
+// FIX: How do we get access to a store inside the components?
+// Shouldn't use of Provider expose the store to all the components contained
+// within the Provider or does it work differently for connected components?
+const RecordListViewIOS = (props, x, y, z) => {
   const renderRecord = (rowData, sectionID, rowID, highlightRow) => {
+    console.log("record", rowData);
     return (
       <RecordListItem record={rowData} />
     );
   };
+  console.log("record list", props.records);
   return(
     <ScrollView style={styles.list}>
       <ListView
-        dataSource={ds.cloneWithRows(props.records)}
+        dataSource={props.ds.cloneWithRows(props.records)}
         renderRow = {renderRecord}
         style = {styles.ListView}
       ></ListView>
     </ScrollView>
   );
 };
+
+RecordListViewIOS.propTypes = {
+  records: PropTypes.array.isRequired,
+  ds: PropTypes.object.isRequired,
+};
+
+export default RecordListViewIOS;

--- a/containers/RecordList.js
+++ b/containers/RecordList.js
@@ -2,9 +2,8 @@
 
 import { connect } from 'react-redux';
 
-import MockData from '../data/records';
-
 const mapStateToProps = (state) => {
+  console.log("mapStateToProps");
   return {
     token: state.token,
     records: state.records

--- a/containers/RecordList.js
+++ b/containers/RecordList.js
@@ -1,0 +1,19 @@
+// TODO: refactor all import statements in codebase to ES6
+
+import { connect } from 'react-redux';
+
+import MockData from '../data/records';
+
+const mapStateToProps = (state) => {
+  return {
+    token: state.token,
+    records: state.records
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps);

--- a/containers/RecordListIOS.js
+++ b/containers/RecordListIOS.js
@@ -1,0 +1,6 @@
+import { connect } from 'react-redux';
+
+import RecordList from './RecordList';
+import RecordListViewIOS from '../components/RecordListViewIOS';
+
+export default RecordList(RecordListViewIOS);

--- a/index.ios.js
+++ b/index.ios.js
@@ -26,21 +26,16 @@ import MockData from './data/records';
 
 const initialState = {
   token: 'YouReallyDidntExpectMeToHardcodeThatOrDidYou?',
-  records: MockData.records
+  records: [], //MockData.records
 };
 
 const store = createStore(basicApp, initialState);
-
-const Main = (props) => {
-  return (
-    <RecordListIOS />
-  );
-}
 
 class NotitieBlok extends Component {
   rightButtonPress() {
     store.dispatch(addRecord(100, 'XTS', 'Autogen'));
     //store.dispatch(
+    return;
       this.refs.nav.navigator.push({
           title: "New Record", // "Camera",
           component: RecordFormViewIOS, //CameraViewIOS,
@@ -58,7 +53,7 @@ class NotitieBlok extends Component {
         ref="nav"
         style={styles.container}
         initialRoute={{
-          component: Main,
+          component: RecordListIOS,
           title: 'Boekingen',
           leftButtonIcon: require('image!NavBarButtonIcon'),
           rightButtonIcon: require('image!NavBarButtonPlus'),

--- a/index.ios.js
+++ b/index.ios.js
@@ -30,11 +30,22 @@ const initialState = {
 };
 
 const store = createStore(basicApp, initialState);
+let unsubscribe = store.subscribe(() => {
+  console.log("state changed to", store.getState());
+});
 
 class NotitieBlok extends Component {
   rightButtonPress() {
-    store.dispatch(addRecord(100, 'XTS', 'Autogen'));
-    //store.dispatch(
+    const titles = [
+      'something happening',
+      'talk to the President',
+      'something something darkside',
+      'make some music',
+      'share some love',
+      'give a stranger a hug',
+      'send mom flowers',
+    ];
+    store.dispatch(addRecord(Math.floor(Math.random()*200), 'XTS', titles[Math.floor(Math.random()*titles.length)]));
     return;
       this.refs.nav.navigator.push({
           title: "New Record", // "Camera",
@@ -47,24 +58,33 @@ class NotitieBlok extends Component {
   }
 
   render() {
+    console.log("NotitieBlok");
+    // FIX: Figure out why rowHasChanged is never fired. Somehow we append the
+    // dataset and perform the cloneWithRows inside components/RecordListViewIOS
+    // but the rowHasChanged check is never executed.
+    let ds = new ListView.DataSource({rowHasChanged: function (r1, r2) {
+      console.log("rowHasChanged", r1, r2);
+      return true; //(r1 !== r2);
+    }});
     return (
       <Provider store={store}>
-      <NavigatorIOS
-        ref="nav"
-        style={styles.container}
-        initialRoute={{
-          component: RecordListIOS,
-          title: 'Boekingen',
-          leftButtonIcon: require('image!NavBarButtonIcon'),
-          rightButtonIcon: require('image!NavBarButtonPlus'),
-          onLeftButtonPress: () => {console.log('pressed')},
-          onRightButtonPress:this.rightButtonPress.bind(this)
-        }}
-        itemWrapperStyle={styles.ItemWrapper}
-        tintColor="#FFF"
-        barTintColor = '#2196F3'
-        titleTextColor = "#FFF"
-      />
+        <NavigatorIOS
+          ref="nav"
+          style={styles.container}
+          initialRoute={{
+            component: RecordListIOS,
+            passProps: { ds: ds },
+            title: 'Boekingen',
+            leftButtonIcon: require('image!NavBarButtonIcon'),
+            rightButtonIcon: require('image!NavBarButtonPlus'),
+            onLeftButtonPress: () => {console.log('pressed')},
+            onRightButtonPress:this.rightButtonPress.bind(this)
+          }}
+          itemWrapperStyle={styles.ItemWrapper}
+          tintColor="#FFF"
+          barTintColor = '#2196F3'
+          titleTextColor = "#FFF"
+        />
       </Provider>
     );
   }

--- a/index.ios.js
+++ b/index.ios.js
@@ -36,7 +36,7 @@ let unsubscribe = store.subscribe(() => {
 
 class NotitieBlok extends Component {
   rightButtonPress() {
-    const titles = [
+    var titles = [
       'something happening',
       'talk to the President',
       'something something darkside',
@@ -45,7 +45,10 @@ class NotitieBlok extends Component {
       'give a stranger a hug',
       'send mom flowers',
     ];
-    store.dispatch(addRecord(Math.floor(Math.random()*200), 'XTS', titles[Math.floor(Math.random()*titles.length)]));
+    var price = Math.floor(Math.random()*200);
+    var title = titles[Math.floor(Math.random()*titles.length)]
+
+    store.dispatch(addRecord(price, 'XTS', title));
     return;
       this.refs.nav.navigator.push({
           title: "New Record", // "Camera",

--- a/index.ios.js
+++ b/index.ios.js
@@ -16,27 +16,31 @@ import React, {
 import CameraViewIOS from './components/CameraViewIOS';
 import RecordFormViewIOS from './components/RecordFormViewIOS';
 import RecordListViewIOS from './components/RecordListViewIOS';
+import RecordListIOS from './containers/RecordListIOS';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { addRecord } from './actions';
+import basicApp from './reducers';
 import styles from './styles/Initial';
 import MockData from './data/records';
 
-class Main extends Component {
-  constructor(props) {
-    super(props)
-    const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
-    this.state = {
-      dataSource: ds.cloneWithRows(MockData.records)
-    }
-  }
+const initialState = {
+  token: 'YouReallyDidntExpectMeToHardcodeThatOrDidYou?',
+  records: MockData.records
+};
 
-  render() {
-    return (
-      <RecordListViewIOS dataSource={this.state.dataSource} />
-    );
-  }
+const store = createStore(basicApp, initialState);
+
+const Main = (props) => {
+  return (
+    <RecordListIOS />
+  );
 }
 
 class NotitieBlok extends Component {
   rightButtonPress() {
+    store.dispatch(addRecord(100, 'XTS', 'Autogen'));
+    //store.dispatch(
       this.refs.nav.navigator.push({
           title: "New Record", // "Camera",
           component: RecordFormViewIOS, //CameraViewIOS,
@@ -49,6 +53,7 @@ class NotitieBlok extends Component {
 
   render() {
     return (
+      <Provider store={store}>
       <NavigatorIOS
         ref="nav"
         style={styles.container}
@@ -65,6 +70,7 @@ class NotitieBlok extends Component {
         barTintColor = '#2196F3'
         titleTextColor = "#FFF"
       />
+      </Provider>
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "react-native-camera": "git+https://github.com/lwansbrough/react-native-camera.git",
     "react-native-extra-dimensions-android": "^0.17.0",
     "react-native-material-design": "^0.3.3",
-    "react-native-vector-icons": "^1.3.4"
+    "react-native-vector-icons": "^1.3.4",
+    "react-redux": "^4.4.5",
+    "redux": "^3.5.2"
   },
   "devDependencies": {
     "eslint": "^2.9.0"

--- a/reducers.js
+++ b/reducers.js
@@ -4,10 +4,10 @@ import { LOAD_RECORD, SAVE_RECORD } from './actions';
 function records(state = [], action) {
   switch(action.type) {
   case SAVE_RECORD:
-      return [
-        action.content,
-        ...state
-      ]
+    return [
+      action.content,
+      ...state
+    ]
   default:
     return state
   }

--- a/reducers.js
+++ b/reducers.js
@@ -1,0 +1,28 @@
+import { combineReducers } from 'redux';
+import { LOAD_RECORD, SAVE_RECORD } from './actions';
+
+function records(state = [], action) {
+  switch(action.type) {
+  case SAVE_RECORD:
+      return [
+        action.content,
+        ...state
+      ]
+  default:
+    return state
+  }
+}
+
+function token(state = null, action) {
+  switch(action.type) {
+  default:
+    return state
+  }
+}
+
+const basicApp = combineReducers({
+  token,
+  records
+});
+
+export default basicApp;


### PR DESCRIPTION
Setting up Redux along with the remaining plumbing necessary to get things going.

Plan is to move to as much [stateless presentational components](http://redux.js.org/docs/basics/UsageWithReact.html#presentational-components) as possible.
# Problem

One thing that is killing me at the moment is rendering of new additions to the dataset. Somehow the state seems to be correcly mutated (e.g.: `state.records` contains the proper data), the `renderRow` method for the listview seems to be called, but the content displayed in the UI seems to be a clone of the first item that was rendered. Another thing of note is that the DataSource's `rowHasChanged` is never called, which may explain why things are broken.

It feels like passing the DataSource in `passProps` is the wrong strategy here. I expected to simply have the [`store` available to everything that is contained by a `Provider`](http://redux.js.org/docs/basics/UsageWithReact.html#passing-the-store) which is aware of the source.
# Some Resources I Briefly Looked At
- https://github.com/reactjs/redux/issues/916
